### PR TITLE
Stratumn account authentication middleware

### DIFF
--- a/lib/auth/account.go
+++ b/lib/auth/account.go
@@ -57,7 +57,7 @@ func (s *StratumnAccountMiddleware) WithAuth(next http.HandlerFunc) http.Handler
 			writeResponse(w, http.StatusInternalServerError, []byte(err.Error()))
 			return
 		}
-		if infoResp.StatusCode == http.StatusUnauthorized {
+		if infoResp.StatusCode >= 400 {
 			b, _ := ioutil.ReadAll(infoResp.Body)
 			writeResponse(w, http.StatusUnauthorized, b)
 			return

--- a/lib/auth/account.go
+++ b/lib/auth/account.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+// Middleware is the interface exposing a middleware function providing authentication.
+type Middleware interface {
+	WithAuth(next http.HandlerFunc) http.HandlerFunc
+}
+
+// StratumnAccountMiddleware implements the Middleware interface.
+// It provides authentication using Stratumn Account API.
+type StratumnAccountMiddleware struct {
+	AccountURL string
+}
+
+// NewStratumnAccountMiddleware returns a new instance of StratumnAccountMiddleware.
+func NewStratumnAccountMiddleware(accountURL string) (Middleware, error) {
+	if accountURL == "" {
+		return nil, errors.New("Stratumn Account API URL is required")
+	}
+	return &StratumnAccountMiddleware{accountURL}, nil
+}
+
+// WithAuth is a middleware function.
+// The incoming request must have an 'authorization' header, which is relayed
+// to the 'GET /info' route of the Account API.
+// The request is rejected if a 401 is returned and goes through otherwise.
+func (s *StratumnAccountMiddleware) WithAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Logged connection from %s", r.RemoteAddr)
+		infoReq, err := http.NewRequest("GET", s.AccountURL+"/info", nil)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// forward the authorization token to Account API.
+		token := r.Header.Get("authorization")
+		if token == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("an authorization tokne must be provided"))
+			return
+		}
+		infoReq.Header.Set("authorization", token)
+
+		infoResp, err := http.DefaultClient.Do(infoReq)
+		if err != nil {
+			b, _ := ioutil.ReadAll(infoResp.Body)
+			w.WriteHeader(infoResp.StatusCode)
+			w.Write(b)
+			return
+		}
+		if infoResp.StatusCode == http.StatusUnauthorized {
+			b, _ := ioutil.ReadAll(infoResp.Body)
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write(b)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}

--- a/lib/auth/account_test.go
+++ b/lib/auth/account_test.go
@@ -1,0 +1,113 @@
+package auth_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stratumn/go-connector/lib/auth"
+)
+
+const (
+	validToken = "Bearer super-secret-token"
+
+	accountAPIError    = "fail"
+	accountAPIResponse = `{"email":"hello@stratumn.com","accountId":"1","otherAccountIds":["1","2"],"userId":"3"}`
+
+	apiResponse = "ok"
+)
+
+func mockStratumnAccount() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/info", func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("authorization") != validToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(accountAPIError))
+			return
+		}
+		fmt.Fprint(w, accountAPIResponse)
+	})
+	ts := httptest.NewServer(mux)
+	return ts
+}
+
+func mockAPI(middleware func(http.HandlerFunc) http.HandlerFunc) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/any", middleware(func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, apiResponse)
+	}))
+	ts := httptest.NewServer(mux)
+	return ts
+}
+
+func TestStratumnAccountMiddleware(t *testing.T) {
+
+	t.Run("Fails if the account URL is not specified", func(t *testing.T) {
+		_, err := auth.NewStratumnAccountMiddleware("test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not instantiate Stratumn Account Auth Middleware")
+	})
+
+	t.Run("Fails if the request does not have an auth token", func(t *testing.T) {
+		accountMock := mockStratumnAccount()
+		defer accountMock.Close()
+
+		m, err := auth.NewStratumnAccountMiddleware(accountMock.URL)
+		require.NoError(t, err)
+
+		apiMock := mockAPI(m.WithAuth)
+		defer apiMock.Close()
+
+		rsp, err := http.Get(apiMock.URL + "/any")
+		require.NoError(t, err)
+
+		b, _ := ioutil.ReadAll(rsp.Body)
+		assert.Equal(t, http.StatusUnauthorized, rsp.StatusCode)
+		assert.Equal(t, []byte(auth.ErrMissingToken.Error()), b)
+	})
+
+	t.Run("Fails if account API returns a 401", func(t *testing.T) {
+		accountMock := mockStratumnAccount()
+		defer accountMock.Close()
+
+		m, err := auth.NewStratumnAccountMiddleware(accountMock.URL)
+		require.NoError(t, err)
+
+		apiMock := mockAPI(m.WithAuth)
+		defer apiMock.Close()
+
+		req, _ := http.NewRequest("GET", apiMock.URL+"/any", nil)
+		req.Header.Set("authorization", "Bearer bad token")
+		rsp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		b, _ := ioutil.ReadAll(rsp.Body)
+		assert.Equal(t, http.StatusUnauthorized, rsp.StatusCode)
+		assert.Equal(t, []byte(accountAPIError), b)
+	})
+
+	t.Run("Serves the next request", func(t *testing.T) {
+		accountMock := mockStratumnAccount()
+		defer accountMock.Close()
+
+		m, err := auth.NewStratumnAccountMiddleware(accountMock.URL)
+		require.NoError(t, err)
+
+		apiMock := mockAPI(m.WithAuth)
+		defer apiMock.Close()
+
+		req, _ := http.NewRequest("GET", apiMock.URL+"/any", nil)
+		req.Header.Set("authorization", validToken)
+		rsp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		b, _ := ioutil.ReadAll(rsp.Body)
+		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, []byte(apiResponse), b)
+	})
+}


### PR DESCRIPTION
This middleware calls account API on the `/info` route and forwards the request if no error was encountered.
It returns a 401 otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-connector/33)
<!-- Reviewable:end -->
